### PR TITLE
Refactoring of Instrument list and Parameters creation

### DIFF
--- a/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
+++ b/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
@@ -6,6 +6,9 @@ from . import exposer
 from urllib.parse import urlsplit, parse_qs, urlencode
 import os
 from glob import glob
+import logging
+
+logger = logging.getLogger()
 
 class NB2WDataDispatcher:
     def __init__(self, instrument=None, param_dict=None, task=None, config=None):
@@ -29,7 +32,6 @@ class NB2WDataDispatcher:
         try:
             options_dict = self._backend_options
         except AttributeError:
-            exceptions = []
             url = self.data_server_url.strip('/') + '/api/v1.0/options'
             for i in range(max_trial):
                 try:
@@ -45,10 +47,10 @@ class NB2WDataDispatcher:
                                            f"Response: {res.text}")
                 except Exception as e:
                     backend_available = False
-                    exceptions.append(e)
+                    logger.error(f"Exception while getting backend options {repr(e)}")
                     time.sleep(sleep_seconds)
             if not backend_available:
-                raise exceptions[-1]
+                return {}
             
             self._backend_options = options_dict
         return options_dict

--- a/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
+++ b/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
@@ -29,6 +29,7 @@ class NB2WDataDispatcher:
         try:
             options_dict = self._backend_options
         except AttributeError:
+            exceptions = []
             url = self.data_server_url.strip('/') + '/api/v1.0/options'
             for i in range(max_trial):
                 try:
@@ -44,9 +45,10 @@ class NB2WDataDispatcher:
                                            f"Response: {res.text}")
                 except Exception as e:
                     backend_available = False
+                    exceptions.append(e)
                     time.sleep(sleep_seconds)
             if not backend_available:
-                raise e
+                raise exceptions[-1]
             
             self._backend_options = options_dict
         return options_dict

--- a/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
+++ b/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
@@ -16,7 +16,7 @@ class NB2WDataDispatcher:
                                                        allowed_keys = ['restricted_access'])
             except:
                 #this happens if the instrument is not found in the instrument config, which is always read from a static file
-                config = DataServerConf.from_conf_dict(exposer.get_instr_conf()['instruments'][iname])
+                config = DataServerConf.from_conf_dict(exposer.get_instr_conf()[0]['kg_instruments'][iname])
             
         self.data_server_url = config.data_server_url
         self.task = task

--- a/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
+++ b/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
@@ -11,12 +11,7 @@ class NB2WDataDispatcher:
     def __init__(self, instrument=None, param_dict=None, task=None, config=None):
         iname = instrument if isinstance(instrument, str) else instrument.name
         if config is None:
-            try:
-                config = DataServerConf.from_conf_dict(exposer.config_dict['instruments'][iname], 
-                                                       allowed_keys = ['restricted_access'])
-            except:
-                #this happens if the instrument is not found in the instrument config, which is always read from a static file
-                config = DataServerConf.from_conf_dict(exposer.get_instr_conf()[0]['kg_instruments'][iname])
+            config = DataServerConf.from_conf_dict(exposer.combined_instrument_dict[iname])
             
         self.data_server_url = config.data_server_url
         self.task = task

--- a/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
+++ b/dispatcher_plugin_nb2workflow/dataserver_dispatcher.py
@@ -21,7 +21,6 @@ class NB2WDataDispatcher:
         self.data_server_url = config.data_server_url
         self.task = task
         self.param_dict = param_dict
-        self.backend_options = self.query_backend_options()
         
         self.external_disp_url = None 
         if not isinstance(instrument, str): # TODO: seems this is always the case. But what if not?
@@ -30,19 +29,23 @@ class NB2WDataDispatcher:
             if parsed.scheme and parsed.netloc:
                 self.external_disp_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
         
-            
-    def query_backend_options(self):
-        url = self.data_server_url.strip('/') + '/api/v1.0/options'
+    @property
+    def backend_options(self):
         try:
-            res = requests.get("%s" % (url), params=None)
-        except:
-            return {}
-        if res.status_code == 200:
-            options_dict = res.json()
-        else:
-            return {}
-            raise ConnectionError(f"Backend connection failed: {res.status_code}")
-            # TODO: consecutive requests if failed
+            options_dict = self._backend_options
+        except AttributeError:
+            url = self.data_server_url.strip('/') + '/api/v1.0/options'
+            try:
+                res = requests.get("%s" % (url), params=None)
+            except:
+                return {}
+            if res.status_code == 200:
+                options_dict = res.json()
+            else:
+                return {}
+                raise ConnectionError(f"Backend connection failed: {res.status_code}")
+                # TODO: consecutive requests if failed
+            self._backend_options = options_dict
         return options_dict
         
     def get_backend_comment(self, product):

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -8,13 +8,14 @@ import yaml
 import requests
 import rdflib as rdf
 import os
+from itertools import chain
 
 import logging
 logger = logging.getLogger(__name__)
 
 
 def kg_select(t, kg_conf_dict):
-    if kg_conf_dict is None:
+    if kg_conf_dict is None or kg_conf_dict == {}:
         logger.info('Not using KG to get instruments')
         qres_js = []
     elif kg_conf_dict.get('type') == 'query-service':
@@ -75,10 +76,9 @@ def get_instrs_from_kg(kg_conf_dict):
 def get_instr_conf(from_conf_file=None):
     masked_conf_file = from_conf_file
     
-    # current default - query central oda kb 
-    # TODO: better default will be some regullary updated static location
-    kg_conf_dict = {'type': 'query-service',  
-                    'path': "https://www.astro.unige.ch/mmoda/dispatch-data/gw/odakb/query"}
+    # kg_conf_dict = {'type': 'query-service',  
+    #                 'path': "https://www.astro.unige.ch/mmoda/dispatch-data/gw/odakb/query"}
+    kg_conf_dict = {}
     cfg_dict = {'instruments': {}}
     
     if from_conf_file is not None:
@@ -155,4 +155,4 @@ class NB2WInstrumentFactoryIter:
                     
 instr_factory_list = [ factory_factory(instr_name, instr_conf.get('restricted_access', False)) 
                        for instr_name, instr_conf in 
-                       config_dict['instruments'].items() + config_dict['kg_instruments'].items() ]
+                       chain(config_dict['instruments'].items(), config_dict['kg_instruments'].items())]

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -102,18 +102,21 @@ else:
 logger.info('Using ontology from %s', ontology_path)
 
 def factory_factory(instr_name, restricted_access):
+    instrument_query = NB2WInstrumentQuery('instr_query', restricted_access)
     def instr_factory():
         backend_options = NB2WDataDispatcher(instrument=instr_name).backend_options
         query_list, query_dict = NB2WProductQuery.query_list_and_dict_factory(backend_options, ontology_path)
         return Instrument(instr_name,
                         src_query = NB2WSourceQuery.from_backend_options(backend_options, ontology_path),
-                        instrumet_query = NB2WInstrumentQuery('instr_query', restricted_access),
+                        instrumet_query = instrument_query,
                         data_serve_conf_file=conf_file,
                         product_queries_list=query_list,
                         query_dictionary=query_dict,
                         asynch=True, 
                         data_server_query_class=NB2WDataDispatcher,
                         )
+    instr_factory.instr_name = instr_name
+    instr_factory.instrument_query = instrument_query
     return instr_factory
 
 instr_factory_list = [ factory_factory(instr_name, instr_conf.get('restricted_access', False)) 

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -95,7 +95,7 @@ def get_instr_conf(from_conf_file=None):
             else:
                 masked_conf_file = None
     
-    cfg_dict['kg_instruments'].update(get_instrs_from_kg(kg_conf_dict))
+    cfg_dict['kg_instruments'] = get_instrs_from_kg(kg_conf_dict)
     
     return cfg_dict, masked_conf_file
 

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -35,7 +35,9 @@ def kg_select(t, kg_conf_dict):
         if os.path.isfile(kg_conf_dict['path']):
             graph.parse(kg_conf_dict['path'])
         else:
-            logger.warning("Knowledge graph file %s doesn't exist yet. No instruments information will be loaded.")
+            logger.warning("Knowledge graph file %s doesn't exist yet. " 
+                           "No instruments information will be loaded.", 
+                           kg_conf_dict['path'])
         qres = graph.query(f"""
                         SELECT * WHERE {{
                             {t}
@@ -52,7 +54,7 @@ def kg_select(t, kg_conf_dict):
     return qres_js
 
 def get_instrs_from_kg(kg_conf_dict):
-    instruments = []
+    instruments = {}
     for r in kg_select('''
         ?w a <http://odahub.io/ontology#WorkflowService>;
         <http://odahub.io/ontology#deployment_name> ?deployment_name;

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -92,11 +92,11 @@ def get_config_dict_from_kg(kg_conf_dict=static_config_dict['kg']):
     cfg_dict = {'instruments': {}}
     
     for r in kg_select('''
-        ?w a <http://odahub.io/ontology#WorkflowService>;
-        <http://odahub.io/ontology#deployment_name> ?deployment_name;
-        <http://odahub.io/ontology#service_name> ?service_name ;
-        <https://schema.org/creativeWorkStatus>?  ?work_status .               
-    ''', kg_conf_dict): 
+                ?w a <http://odahub.io/ontology#WorkflowService>;
+                <http://odahub.io/ontology#deployment_name> ?deployment_name;
+                <http://odahub.io/ontology#service_name> ?service_name ;
+                <https://schema.org/creativeWorkStatus>?  ?work_status .
+            ''', kg_conf_dict): 
 
         logger.info('found instrument service record %s', r)
         cfg_dict['instruments'][r['service_name']['value']] = {

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -103,7 +103,7 @@ logger.info('Using ontology from %s', ontology_path)
 
 def factory_factory(instr_name, restricted_access):
     def instr_factory():
-        backend_options = NB2WDataDispatcher(instrument=instr_name).query_backend_options()
+        backend_options = NB2WDataDispatcher(instrument=instr_name).backend_options
         query_list, query_dict = NB2WProductQuery.query_list_and_dict_factory(backend_options, ontology_path)
         return Instrument(instr_name,
                         src_query = NB2WSourceQuery.from_backend_options(backend_options, ontology_path),

--- a/dispatcher_plugin_nb2workflow/exposer.py
+++ b/dispatcher_plugin_nb2workflow/exposer.py
@@ -8,7 +8,7 @@ import yaml
 import requests
 import rdflib as rdf
 import os
-from itertools import chain
+from copy import copy
 
 import logging
 logger = logging.getLogger(__name__)
@@ -54,35 +54,16 @@ def kg_select(t, kg_conf_dict):
     
     return qres_js
 
-def get_instrs_from_kg(kg_conf_dict):
-    instruments = {}
-    for r in kg_select('''
-        ?w a <http://odahub.io/ontology#WorkflowService>;
-        <http://odahub.io/ontology#deployment_name> ?deployment_name;
-        <http://odahub.io/ontology#service_name> ?service_name ;
-        <https://schema.org/creativeWorkStatus>?  ?work_status .               
-    ''', kg_conf_dict): 
-
-        logger.info('found instrument service record %s', r)
-        instruments[r['service_name']['value']] = {
-            "data_server_url": f"http://{r['deployment_name']['value']}:8000",
-            "dummy_cache": "",
-            "restricted_access": False if r['work_status']['value'] == "production" else True
-        }
-    
-    return instruments
-    
-    
-def get_instr_conf(from_conf_file=None):
-    masked_conf_file = from_conf_file
+def get_static_instr_conf(conf_file):
+    masked_conf_file = conf_file
     
     # kg_conf_dict = {'type': 'query-service',  
     #                 'path': "https://www.astro.unige.ch/mmoda/dispatch-data/gw/odakb/query"}
-    kg_conf_dict = {}
-    cfg_dict = {'instruments': {}}
     
-    if from_conf_file is not None:
-        with open(from_conf_file, 'r') as ymlfile:
+    cfg_dict = {'instruments': {}, 'kg': {}}
+    
+    if conf_file is not None:
+        with open(conf_file, 'r') as ymlfile:
             f_cfg_dict = yaml.load(ymlfile, Loader=yaml.SafeLoader)
             if f_cfg_dict is not None:
                 if 'instruments' in f_cfg_dict.keys():
@@ -93,29 +74,56 @@ def get_instr_conf(from_conf_file=None):
                 if 'ontology_path' in f_cfg_dict.keys():
                     cfg_dict['ontology_path'] = f_cfg_dict['ontology_path']
                 if 'kg' in f_cfg_dict.keys():
-                    kg_conf_dict = f_cfg_dict['kg']
+                    cfg_dict['kg'] = f_cfg_dict['kg']
             else:
                 masked_conf_file = None
-    
-    cfg_dict['kg_instruments'] = get_instrs_from_kg(kg_conf_dict)
-    
     return cfg_dict, masked_conf_file
 
-config_dict, masked_conf_file = get_instr_conf(conf_file)
+static_config_dict, masked_conf_file = get_static_instr_conf(conf_file)
+
 if 'ODA_ONTOLOGY_PATH' in os.environ:
     ontology_path = os.environ.get('ODA_ONTOLOGY_PATH')
 else:
-    ontology_path = config_dict.get('ontology_path', 
+    ontology_path = static_config_dict.get('ontology_path', 
                                     'http://odahub.io/ontology/ontology.ttl')
 logger.info('Using ontology from %s', ontology_path)
+
+def get_config_dict_from_kg(kg_conf_dict=static_config_dict['kg']):
+    cfg_dict = {'instruments': {}}
+    
+    for r in kg_select('''
+        ?w a <http://odahub.io/ontology#WorkflowService>;
+        <http://odahub.io/ontology#deployment_name> ?deployment_name;
+        <http://odahub.io/ontology#service_name> ?service_name ;
+        <https://schema.org/creativeWorkStatus>?  ?work_status .               
+    ''', kg_conf_dict): 
+
+        logger.info('found instrument service record %s', r)
+        cfg_dict['instruments'][r['service_name']['value']] = {
+            "data_server_url": f"http://{r['deployment_name']['value']}:8000",
+            "dummy_cache": "",
+            "restricted_access": False if r['work_status']['value'] == "production" else True
+        }
+    
+    return cfg_dict
+
+combined_instrument_dict = {}
+def build_combined_instrument_dict():
+    global combined_instrument_dict
+    combined_instrument_dict = copy(static_config_dict.get('instruments', {}))
+    combined_instrument_dict.update(get_config_dict_from_kg()['instruments'])
+
+build_combined_instrument_dict()
 
 def factory_factory(instr_name, restricted_access):
     instrument_query = NB2WInstrumentQuery('instr_query', restricted_access)
     def instr_factory():
         backend_options = NB2WDataDispatcher(instrument=instr_name).backend_options
-        query_list, query_dict = NB2WProductQuery.query_list_and_dict_factory(backend_options, ontology_path)
+        query_list, query_dict = NB2WProductQuery.query_list_and_dict_factory(backend_options, 
+                                                                              ontology_path)
         return Instrument(instr_name,
-                        src_query = NB2WSourceQuery.from_backend_options(backend_options, ontology_path),
+                        src_query = NB2WSourceQuery.from_backend_options(backend_options, 
+                                                                         ontology_path),
                         instrumet_query = instrument_query,
                         data_serve_conf_file=masked_conf_file,
                         product_queries_list=query_list,
@@ -132,11 +140,10 @@ class NB2WInstrumentFactoryIter:
         self.lst = lst
     
     def _update_instruments_list(self):
-        static_instrs = config_dict['instruments']
-        kg_instrs = get_instrs_from_kg(config_dict)
+        build_combined_instrument_dict()
         
         current_instrs = [x.instr_name for x in self.lst]
-        available_instrs = static_instrs.keys() + kg_instrs.keys()
+        available_instrs = combined_instrument_dict.keys()
         new_instrs = set(available_instrs) - set(current_instrs)
         old_instrs = set(current_instrs) - set(available_instrs)
         
@@ -147,12 +154,13 @@ class NB2WInstrumentFactoryIter:
         
         if new_instrs:
             for instr in new_instrs:
-                self.lst.append(factory_factory(instr, kg_instrs[instr].get('restricted_access', False)))
+                self.lst.append(factory_factory(instr, combined_instrument_dict[instr].get('restricted_access', False)))
         
     def __iter__(self):
         self._update_instruments_list()
         return self.lst.__iter__()    
                     
 instr_factory_list = [ factory_factory(instr_name, instr_conf.get('restricted_access', False)) 
-                       for instr_name, instr_conf in 
-                       chain(config_dict['instruments'].items(), config_dict['kg_instruments'].items())]
+                       for instr_name, instr_conf in combined_instrument_dict.items()]
+
+instr_factory_list = NB2WInstrumentFactoryIter(instr_factory_list)

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -5,7 +5,8 @@ import json
 from cdci_data_analysis.analysis.products import LightCurveProduct, BaseQueryProduct, ImageProduct, SpectrumProduct
 from cdci_data_analysis.analysis.parameters import Parameter, subclasses_recursive
 from oda_api.data_products import NumpyDataProduct, ODAAstropyTable, BinaryProduct, PictureProduct
-from .util import AstropyTableViewParser, ParProdOntology
+from .util import AstropyTableViewParser
+from cdci_data_analysis.analysis.ontology import Ontology
 from io import StringIO
 from functools import lru_cache  
 from mimetypes import guess_extension
@@ -110,7 +111,7 @@ class NB2WParameterProduct(NB2WProduct):
     type_key = 'oda:WorkflowParameter'
     
     ontology_path = None
-    
+        
     def __init__(self, 
                  value, 
                  out_dir=None, 
@@ -132,11 +133,11 @@ class NB2WParameterProduct(NB2WProduct):
 @lru_cache
 def parameter_products_factory(ontology_path = None):
     classes = []
-    onto = ParProdOntology(ontology_path)
+    onto = Ontology(ontology_path)
     for term in onto.get_parprod_terms():
         classes.append(type(f"{term.split('#')[-1]}Product", 
                             (NB2WParameterProduct,), 
-                            {'type_key': term, 'ontology_path': ontology_path}))
+                            {'type_key': term, 'ontology_object': onto}))
     return classes
         
 

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -12,19 +12,25 @@ from cdci_data_analysis.analysis.ontology import Ontology
 import os
 from functools import lru_cache
 from json import dumps
+from copy import copy
 
 class HashableDict(dict):
     def __hash__(self):
         return hash(dumps(self, sort_keys=True))
+
+def copying_lru_cache(func):
+    def wrapper(backend_param_dict, ontology_path):
+        cached_func = lru_cache()(func)
+        return copy(cached_func(backend_param_dict, ontology_path))
+    return wrapper
 
 def with_hashable_dict(func):
     def wrapper(backend_param_dict, ontology_path):
         return func(HashableDict(backend_param_dict), ontology_path)
     return wrapper
 
-
 @with_hashable_dict
-@lru_cache
+@copying_lru_cache
 def construct_parameter_lists(backend_param_dict, ontology_path):
     src_query_pars_uris = { "http://odahub.io/ontology#PointOfInterestRA": "RA",
                             "http://odahub.io/ontology#PointOfInterestDEC": "DEC",

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -46,24 +46,24 @@ def construct_parameter_signatures(backend_param_dict, ontology_path):
         if src_query_owl_uri_set:
             default_pname = src_query_pars_uris[src_query_owl_uri_set.pop()]
             par_name_substitution[ default_pname ] = pname
-            source_plist.append(Parameter.from_owl_uri(pval['owl_type'],
-                                                       value=pval['default_value'],
-                                                       name=default_pname,
-                                                       ontology_path=onto,
-                                                       extra_ttl=pval.get("extra_ttl")
-                                                       ))
+            source_plist.append(Parameter.instance_signature_from_owl_uri(pval['owl_type'],
+                                                                          value=pval['default_value'],
+                                                                          name=default_pname,
+                                                                          ontology_path=onto,
+                                                                          extra_ttl=pval.get("extra_ttl")
+                                                                          ))
         else:
             #if param name coincides with the SourceQuery default names, but it's not properly annotated, rename
             cur_name = pname
             if pname in src_query_pars_uris.values():
                 cur_name = pname + '_rename'
                 par_name_substitution[ cur_name ] = pname
-            plist.append(Parameter.from_owl_uri(pval['owl_type'],
-                                                value=pval['default_value'],
-                                                name=cur_name,
-                                                ontology_path=onto,
-                                                extra_ttl=pval.get("extra_ttl")
-                                                ))
+            plist.append(Parameter.instance_signature_from_owl_uri(pval['owl_type'],
+                                                                   value=pval['default_value'],
+                                                                   name=cur_name,
+                                                                   ontology_path=onto,
+                                                                   extra_ttl=pval.get("extra_ttl")
+                                                                   ))
     return {'source_p_cls': [x[1] for x in source_plist],
             'source_p_kw': [x[2] for x in source_plist],
             'prod_p_cls': [x[1] for x in plist],

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -15,7 +15,7 @@ from json import dumps
 
 class HashableDict(dict):
     def __hash__(self):
-        return hash(dumps(self))
+        return hash(dumps(self, sort_keys=True))
 
 def with_hashable_dict(func):
     def wrapper(backend_param_dict, ontology_path):
@@ -25,12 +25,14 @@ def with_hashable_dict(func):
 
 @with_hashable_dict
 @lru_cache
-def construct_parameter_lists(backend_param_dict, ontology_path):
+def construct_parameter_signatures(backend_param_dict, ontology_path):
     src_query_pars_uris = { "http://odahub.io/ontology#PointOfInterestRA": "RA",
                             "http://odahub.io/ontology#PointOfInterestDEC": "DEC",
                             "http://odahub.io/ontology#StartTime": "T1",
                             "http://odahub.io/ontology#EndTime": "T2",
-                            "http://odahub.io/ontology#AstrophysicalObject": "src_name"}
+                            "http://odahub.io/ontology#AstrophysicalObject": "src_name",
+                            #"ThisTermShouldNotExist": "token"
+                          }
     par_name_substitution = {}
 
     plist = []
@@ -47,7 +49,7 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
             source_plist.append(Parameter.from_owl_uri(pval['owl_type'],
                                                        value=pval['default_value'],
                                                        name=default_pname,
-                                                       ontology_path=ontology_path,
+                                                       ontology_path=onto,
                                                        extra_ttl=pval.get("extra_ttl")
                                                        ))
         else:
@@ -59,13 +61,28 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
             plist.append(Parameter.from_owl_uri(pval['owl_type'],
                                                 value=pval['default_value'],
                                                 name=cur_name,
-                                                ontology_path=ontology_path,
+                                                ontology_path=onto,
                                                 extra_ttl=pval.get("extra_ttl")
                                                 ))
-
+    return {'source_p_cls': [x[1] for x in source_plist],
+            'source_p_kw': [x[2] for x in source_plist],
+            'prod_p_cls': [x[1] for x in plist],
+            'prod_p_kw': [x[2] for x in plist],
+            'par_name_substitution': par_name_substitution
+            }
+    
+def construct_parameter_lists(backend_param_dict, ontology_path):
+    signatures = construct_parameter_signatures(backend_param_dict, ontology_path)
+    source_plist = []
+    for i, cls in enumerate(signatures['source_p_cls']):
+        source_plist.append(cls(**signatures['source_p_kw'][i]))
+    prod_plist = []
+    for i, cls in enumerate(signatures['prod_p_cls']):
+        prod_plist.append(cls(**signatures['prod_p_kw']))
+        
     return {'source_plist': source_plist,
-            'prod_plist': plist,
-            'par_name_substitution': par_name_substitution}
+            'prod_plist': prod_plist,
+            'par_name_substitution': signatures['par_name_substitution']}
 
 class NB2WSourceQuery(BaseQuery):
     @classmethod

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -32,7 +32,7 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
                             "http://odahub.io/ontology#StartTime": "T1",
                             "http://odahub.io/ontology#EndTime": "T2",
                             "http://odahub.io/ontology#AstrophysicalObject": "src_name",
-                            #"ThisNameShouldNotExist": "token"
+                            "ThisNameShouldNotExist": "token"
                           }
     par_name_substitution = {}
 

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -50,7 +50,7 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
             source_plist.append(Parameter.from_owl_uri(pval['owl_type'],
                                                        value=pval['default_value'],
                                                        name=default_pname,
-                                                       ontology_path=onto,
+                                                       ontology_object=onto,
                                                        extra_ttl=pval.get("extra_ttl")
                                                        ))
         else:
@@ -62,7 +62,7 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
             plist.append(Parameter.from_owl_uri(pval['owl_type'],
                                                 value=pval['default_value'],
                                                 name=cur_name,
-                                                ontology_path=onto,
+                                                ontology_object=onto,
                                                 extra_ttl=pval.get("extra_ttl")
                                                 ))
     return {'source_plist': source_plist,

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -40,7 +40,7 @@ def construct_parameter_signatures(backend_param_dict, ontology_path):
     for pname, pval in backend_param_dict.items():
         onto = Ontology(ontology_path)
         if pval.get("extra_ttl"):
-            onto.parse_extra_triples(pval.get("extra_ttl"))
+            onto.parse_extra_triples(pval.get("extra_ttl"), parse_oda_annotations = False)
         onto_class_hierarchy = onto.get_parameter_hierarchy(pval['owl_type'])
         src_query_owl_uri_set = set(onto_class_hierarchy).intersection(src_query_pars_uris.keys())
         if src_query_owl_uri_set:

--- a/dispatcher_plugin_nb2workflow/queries.py
+++ b/dispatcher_plugin_nb2workflow/queries.py
@@ -78,7 +78,7 @@ def construct_parameter_lists(backend_param_dict, ontology_path):
         source_plist.append(cls(**signatures['source_p_kw'][i]))
     prod_plist = []
     for i, cls in enumerate(signatures['prod_p_cls']):
-        prod_plist.append(cls(**signatures['prod_p_kw']))
+        prod_plist.append(cls(**signatures['prod_p_kw'][i]))
         
     return {'source_plist': source_plist,
             'prod_plist': prod_plist,

--- a/dispatcher_plugin_nb2workflow/util.py
+++ b/dispatcher_plugin_nb2workflow/util.py
@@ -1,20 +1,4 @@
 from html.parser import HTMLParser
-from cdci_data_analysis.analysis.ontology import Ontology
-
-class ParProdOntology(Ontology):
-    def get_parprod_terms(self):
-        query = """
-            SELECT ?s WHERE {
-                ?s (rdfs:subClassOf|a)* ?mid0.
-                ?mid0 rdfs:subClassOf* oda:DataProduct. 
-
-                ?s (rdfs:subClassOf|a)* ?mid1.
-                ?mid1 rdfs:subClassOf* oda:WorkflowParameter .
-            }
-            GROUP BY ?s
-            """
-        qres = self.g.query(query)
-        return [str(row[0]) for row in qres]
 
 class AstropyTableViewParser(HTMLParser):
     def handle_starttag(self, tag, attrs):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/oda-hub/nb2workflow.git@master#egg=nb2workflow[service,rdf]
 git+https://github.com/oda-hub/oda_api.git@master#egg=oda_api
-git+https://github.com/oda-hub/dispatcher-app.git@master#egg=cdci_data_analysis
+git+https://github.com/oda-hub/dispatcher-app.git@from-owl-signature#egg=cdci_data_analysis

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from pytest_httpserver.httpserver import MappingQueryMatcher
 config_one_instrument = """    
 instruments:
   example0:
-    data_server_url: http://localhost:9494
+    data_server_url: http://localhost:8000
     dummy_cache: ""
 """
 
@@ -40,7 +40,7 @@ def get_backend_status():
 
 @pytest.fixture(scope="session")
 def httpserver_listen_address():
-    return ("127.0.0.1", 9494)
+    return ("127.0.0.1", 8000)
 
 
 def lightcurve_handler(request: Request):

--- a/tests/example_nb/echo.ipynb
+++ b/tests/example_nb/echo.ipynb
@@ -27,7 +27,8 @@
     "visible_band = \"v\" # oda:PhotometricBand ; oda:allowed_value \"b\", \"g\", \"r\", \"v\"\n",
     "radius = 3. # oda:Angle ; oda:unit unit:arcmin\n",
     "energy = 50. # oda:Energy_keV ; oda:lower_limit 35 ; oda:upper_limit 800\n",
-    "time_instant = '2017-08-17T12:43:0.000' # oda:TimeInstantISOT"
+    "time_instant = '2017-08-17T12:43:0.000' # oda:TimeInstantISOT\n",
+    "token = \"XGDSgs2KYqHr\""
    ]
   },
   {
@@ -45,6 +46,7 @@
     "                  radius=radius,\n",
     "                  energy=energy,\n",
     "                  time_instant=time_instant,\n",
+    "                  token=token,\n",
     "                  )"
    ]
   },

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -462,7 +462,7 @@ def test_parameter_output(live_nb2service,
                           ('mrk', 'Mrk 421', 'http://odahub.io/ontology#AstrophysicalObject'),
                           ('timeinst', 56457.0, 'http://odahub.io/ontology#TimeInstantMJD'),
                           ('timeisot',
-                          '2022-10-09T13:00:00.000',
+                          '2022-10-09T13:00:00',
                           'http://odahub.io/ontology#TimeInstantISOT'),
                           ('wrng', 'FOO', 'http://odahub.io/ontology#PhotometricBand')]
         

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -371,9 +371,10 @@ def test_local_kg(conf_file, dispatcher_live_fixture, privileged):
                           
                           ({'visible_band': 'z'}, {'visible_band': 'z'}, True),
                           
-                          ({'energy': 1000}, {'energy': 1000}, True)
+                          ({'energy': 1000}, {'energy': 1000}, True),
+                          ({'token_rename': 'aZH17bvYmP0r'}, {'token': 'aZH17bvYmP0r'}, False),
                           ])
-def test_full_stack(live_nb2service,
+def test_echo_params(live_nb2service,
                     conf_file, 
                     dispatcher_live_fixture,  
                     set_param, 
@@ -401,7 +402,8 @@ def test_full_stack(live_nb2service,
                           'radius': 3.0, 
                           'start_time': 56000.0, 
                           'time_instant': '2017-08-17T12:43:00.000', 
-                          'visible_band': 'v'}
+                          'visible_band': 'v',
+                          'token': "XGDSgs2KYqHr"}
         request_params = {}
         expected_params = default_in_params.copy()
         
@@ -867,3 +869,4 @@ def test_kg_based_instrument_parameters(conf_file, dispatcher_live_fixture, capl
         with open(conf_file, 'w') as fd:
             fd.write(conf_bk)        
         os.remove(tmpkg)
+


### PR DESCRIPTION
Refactoring in Instruments/Parameters creation. For optimisation and bug-fixing. This will really reduce the overhead and there will be no more gateway timeouts, I hope.
 
- Reduce the number of requests for the backend description.
- No need to reload the plugin to update the information from KG about available instruments (it gets updated before an iteration of the instrument factory "list").
- `instr_name` and `instrument_query` are attached as attributes to the `instrument_factory`. This allows to avoid the creation of every Instrument in each request.
- Fixed issue with changing default values, still keeping lru_cache for parameter lists.  
- Fixed issue with "token" parameter name masking.
- Pass `Ontology` instance to `Parameter.from_owl_uri` in order to not recreate it.

NOTE: one breaking change is introduced. The default KG url is removed, as the info in kg is really deployment-specific. 