### PR TITLE
fix test no backend

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Test with pytest
       run: |
         curl -o $ODA_ONTOLOGY_PATH https://raw.githubusercontent.com/oda-hub/ontology/ecdf2a61f87aac13ae7a96c0f3dad960312adae4/ontology.ttl
-        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "not fullstack" -sv -n0 --full-trace --log-cli-level=DEBUG 
+        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "not fullstack" -sv --full-trace --log-cli-level=DEBUG 
     - name: Test full stack
       run: |
-        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "fullstack" -sv -n0 --full-trace --log-cli-level=DEBUG 
+        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "fullstack" -sv --full-trace --log-cli-level=DEBUG 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Test with pytest
       run: |
         curl -o $ODA_ONTOLOGY_PATH https://raw.githubusercontent.com/oda-hub/ontology/ecdf2a61f87aac13ae7a96c0f3dad960312adae4/ontology.ttl
-        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "not fullstack" -sv --full-trace --log-cli-level=DEBUG 
+        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "not fullstack" -sv -n0 --full-trace --log-cli-level=DEBUG 
     - name: Test full stack
       run: |
-        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "fullstack" -sv --full-trace --log-cli-level=DEBUG 
+        python -m coverage run --source=dispatcher_plugin_nb2workflow -m pytest tests -m "fullstack" -sv -n0 --full-trace --log-cli-level=DEBUG 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from cdci_data_analysis.pytest_fixtures import (
+            kill_child_processes,
             dispatcher_debug,
             dispatcher_test_conf_fn,
             dispatcher_test_conf_with_external_products_url_fn,
@@ -192,7 +193,18 @@ def live_nb2service(xprocess):
         logfile = xprocess.ensure("nb2service", Starter)
 
     except Exception as e:
-        xprocess.getinfo("nb2service").terminate()
+        process_info = xprocess.getinfo('nb2service')
+        pid = process_info.pid
+        kill_child_processes(pid, signal.SIGINT)
+        os.kill(pid, signal.SIGINT)
+        process_info.terminate()
         raise e
     yield 'http://localhost:9393/'
-    xprocess.getinfo("nb2service").terminate()
+    process_info = xprocess.getinfo('nb2service')
+    pid = process_info.pid
+
+    kill_child_processes(pid, signal.SIGINT)
+    os.kill(pid, signal.SIGINT)
+
+    process_info.terminate()
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -134,7 +134,7 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'table': 'table_query'}
 
 def test_mock_server_lifetime():
-    resp = requests.get('http://127.0.0.1:9000')
+    resp = requests.get('http://127.0.0.1:8000')
     assert resp.status_code == 200
 
 def test_instrument_backend_unavailable(dispatcher_live_fixture):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -68,7 +68,24 @@ def test_discover_plugin():
     import cdci_data_analysis.plugins.importer as importer
 
     assert 'dispatcher_plugin_nb2workflow' in  importer.cdci_plugins_dict.keys()
-    
+
+def test_instrument_backend_unavailable(dispatcher_live_fixture):
+    # current behaviour is to have instrument with no products, could be changed in the future
+    server = dispatcher_live_fixture
+    logger.info("constructed server: %s", server)
+       
+    c = requests.get(server + "/api/meta-data",
+                    params = {'instrument': 'example0'})
+    logger.info("content: %s", c.text)
+    jdata = c.json()
+    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
+    logger.info(jdata)
+    assert c.status_code == 200
+    for elem in jdata[0]:
+        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
+            prod_dict = elem['prod_dict']
+    assert prod_dict == {}
+
 def test_instrument_available(dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
@@ -133,23 +150,6 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'lightcurve': 'lightcurve_query',
                          'table': 'table_query'}
 
-
-def test_instrument_backend_unavailable(dispatcher_live_fixture):
-    # current behaviour is to have instrument with no products, could be changed in the future
-    server = dispatcher_live_fixture
-    logger.info("constructed server: %s", server)
-       
-    c = requests.get(server + "/api/meta-data",
-                    params = {'instrument': 'example0'})
-    logger.info("content: %s", c.text)
-    jdata = c.json()
-    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
-    logger.info(jdata)
-    assert c.status_code == 200
-    for elem in jdata[0]:
-        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
-            prod_dict = elem['prod_dict']
-    assert prod_dict == {}
 
 def test_instrument_added(conf_file, dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -68,24 +68,7 @@ def test_discover_plugin():
     import cdci_data_analysis.plugins.importer as importer
 
     assert 'dispatcher_plugin_nb2workflow' in  importer.cdci_plugins_dict.keys()
-
-def test_instrument_backend_unavailable(dispatcher_live_fixture):
-    # current behaviour is to have instrument with no products, could be changed in the future
-    server = dispatcher_live_fixture
-    logger.info("constructed server: %s", server)
-       
-    c = requests.get(server + "/api/meta-data",
-                    params = {'instrument': 'example0'})
-    logger.info("content: %s", c.text)
-    jdata = c.json()
-    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
-    logger.info(jdata)
-    assert c.status_code == 200
-    for elem in jdata[0]:
-        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
-            prod_dict = elem['prod_dict']
-    assert prod_dict == {}
-
+    
 def test_instrument_available(dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
@@ -150,6 +133,23 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'lightcurve': 'lightcurve_query',
                          'table': 'table_query'}
 
+
+def test_instrument_backend_unavailable(dispatcher_live_fixture):
+    # current behaviour is to have instrument with no products, could be changed in the future
+    server = dispatcher_live_fixture
+    logger.info("constructed server: %s", server)
+       
+    c = requests.get(server + "/api/meta-data",
+                    params = {'instrument': 'example0'})
+    logger.info("content: %s", c.text)
+    jdata = c.json()
+    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
+    logger.info(jdata)
+    assert c.status_code == 200
+    for elem in jdata[0]:
+        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
+            prod_dict = elem['prod_dict']
+    assert prod_dict == {}
 
 def test_instrument_added(conf_file, dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -68,7 +68,26 @@ def test_discover_plugin():
     import cdci_data_analysis.plugins.importer as importer
 
     assert 'dispatcher_plugin_nb2workflow' in  importer.cdci_plugins_dict.keys()
-    
+
+
+def test_instrument_backend_unavailable(dispatcher_live_fixture):
+    # current behaviour is to have instrument with no products, could be changed in the future
+    server = dispatcher_live_fixture
+    logger.info("constructed server: %s", server)
+       
+    c = requests.get(server + "/api/meta-data",
+                    params = {'instrument': 'example0'})
+    logger.info("content: %s", c.text)
+    jdata = c.json()
+    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
+    logger.info(jdata)
+    assert c.status_code == 200
+    for elem in jdata[0]:
+        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
+            prod_dict = elem['prod_dict']
+    assert prod_dict == {}
+
+
 def test_instrument_available(dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
@@ -132,27 +151,6 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'file_download': 'file_download_query',
                          'lightcurve': 'lightcurve_query',
                          'table': 'table_query'}
-
-def test_mock_server_lifetime():
-    resp = requests.get('http://127.0.0.1:8000')
-    assert resp.status_code == 200
-
-def test_instrument_backend_unavailable(dispatcher_live_fixture):
-    # current behaviour is to have instrument with no products, could be changed in the future
-    server = dispatcher_live_fixture
-    logger.info("constructed server: %s", server)
-       
-    c = requests.get(server + "/api/meta-data",
-                    params = {'instrument': 'example0'})
-    logger.info("content: %s", c.text)
-    jdata = c.json()
-    logger.info(json.dumps(jdata, indent=4, sort_keys=True))
-    logger.info(jdata)
-    assert c.status_code == 200
-    for elem in jdata[0]:
-        if isinstance(elem, dict) and 'prod_dict' in elem.keys():
-            prod_dict = elem['prod_dict']
-    assert prod_dict == {}
 
 def test_instrument_added(conf_file, dispatcher_live_fixture, mock_backend):
     server = dispatcher_live_fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -134,8 +134,9 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'table': 'table_query'}
 
 
-def test_instrument_backend_unavailable(dispatcher_live_fixture):
+def test_instrument_backend_unavailable(dispatcher_live_fixture, mock_backend):
     # current behaviour is to have instrument with no products, could be changed in the future
+    mock_backend.stop()
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
        

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -133,6 +133,7 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'lightcurve': 'lightcurve_query',
                          'table': 'table_query'}
 
+
 def test_instrument_backend_unavailable(dispatcher_live_fixture):
     # current behaviour is to have instrument with no products, could be changed in the future
     server = dispatcher_live_fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -82,10 +82,6 @@ def test_instrument_available(dispatcher_live_fixture, mock_backend):
     assert c.status_code == 200
     assert 'example0' in jdata
 
-def test_mock_server_lifetime():
-    resp = requests.get('http://127.0.0.1:9000')
-    assert resp.status_code == 200
-
 def test_instrument_parameters(dispatcher_live_fixture, caplog, mock_backend):
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
@@ -137,6 +133,9 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'lightcurve': 'lightcurve_query',
                          'table': 'table_query'}
 
+def test_mock_server_lifetime():
+    resp = requests.get('http://127.0.0.1:9000')
+    assert resp.status_code == 200
 
 def test_instrument_backend_unavailable(dispatcher_live_fixture):
     # current behaviour is to have instrument with no products, could be changed in the future

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -82,6 +82,10 @@ def test_instrument_available(dispatcher_live_fixture, mock_backend):
     assert c.status_code == 200
     assert 'example0' in jdata
 
+def test_mock_server_lifetime():
+    resp = requests.get('http://127.0.0.1:9000')
+    assert resp.status_code == 200
+
 def test_instrument_parameters(dispatcher_live_fixture, caplog, mock_backend):
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
@@ -134,9 +138,8 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'table': 'table_query'}
 
 
-def test_instrument_backend_unavailable(dispatcher_live_fixture, httpserver):
+def test_instrument_backend_unavailable(dispatcher_live_fixture):
     # current behaviour is to have instrument with no products, could be changed in the future
-    httpserver.stop()
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
        

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -134,9 +134,9 @@ def test_instrument_products(dispatcher_live_fixture, mock_backend):
                          'table': 'table_query'}
 
 
-def test_instrument_backend_unavailable(dispatcher_live_fixture, mock_backend):
+def test_instrument_backend_unavailable(dispatcher_live_fixture, httpserver):
     # current behaviour is to have instrument with no products, could be changed in the future
-    mock_backend.stop()
+    httpserver.stop()
     server = dispatcher_live_fixture
     logger.info("constructed server: %s", server)
        


### PR DESCRIPTION
One [test](https://github.com/oda-hub/dispatcher-plugin-nb2workflow/blob/9ea4d3c8202ca500e3cc0bf9f7a2ffb9d4755d4f/tests/test_plugin.py#L136) that requires backend to be unavailable started to fail (https://github.com/oda-hub/dispatcher-app/actions/runs/10352765910/job/28765875291) due to recent update in `pytest-httpserver` library.
Normally, due to the [documentation](https://pytest-httpserver.readthedocs.io/en/latest/tutorial.html#server-lifetime) the mock server stays alive between tests, just resetting its "state". Given that, one can't expect it to be unreachable in this test anyway, and the test used to work only because of the peculiarities of how and when the server state is being reset.
Moving this test to be run before mock server was started to assure it works correctly. (Normally, pytest respects the ordering of the tests in the module, from top to bottom.)

Also, this PR includes changes to make sure that subprocesses (if any) of xprocess-started backend are killed 