### PR TITLE
`get_html_draw` function to check the content of the header

### DIFF
--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -422,9 +422,9 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
         # Note that if criteria are not met, it will end up with taking the last extension.
         # In the case a new instrument is added, a further adaptation might be needed.
         data_id = 0
-        if len(self.dispatcher_data_prod.data.data_unit) >= 1:
+        if len(self.dispatcher_data_prod.data.data_unit) > 1:
             for unit_id, unit in enumerate(self.dispatcher_data_prod.data.data_unit):
-                if unit.header.get('IMATYPE', '') == 'SIGNIFICANCE' and unit.header.get('XTENSION', '') == 'IMAGE':
+                if unit.data is not None and unit.header.get('IMATYPE', '') == 'SIGNIFICANCE' and unit.header.get('XTENSION', '') == 'IMAGE':
                     data_id = unit_id
                     break
 

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -417,13 +417,17 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
                          extra_metadata=extra_metadata)
 
     def get_html_draw(self):
-
+        # If there is only one extension of the fits file, it is a primary, and therefore it is the only one suitable to be an image.
+        # The other option is specific to INTEGRAL products, where we want to display the significance map among other extensions.
+        # Note that if criteria are not met, it will end up with taking the last extension.
+        # It is an improvement on the current situation, but should we add new instruments, we might need to introduce adaptations.
+        data_id = 0
         if len(self.dispatcher_data_prod.data.data_unit) == 1:
             data_id = 0
         else:
-            for id, unit in enumerate(self.dispatcher_data_prod.data.data_unit):
+            for unit_id, unit in enumerate(self.dispatcher_data_prod.data.data_unit):
                 if unit.header.get('IMATYPE', '') == 'SIGNIFICANCE' and unit.header.get('XTENSION', '') == 'IMAGE':
-                    data_id = id
+                    data_id = unit_id
                     break
 
         return self.dispatcher_data_prod.get_html_draw(data_ID=data_id)  # type: ignore

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -422,9 +422,7 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
         # Note that if criteria are not met, it will end up with taking the last extension.
         # In the case a new instrument is added, a further adaptation might be needed.
         data_id = 0
-        if len(self.dispatcher_data_prod.data.data_unit) == 1:
-            data_id = 0
-        else:
+        if len(self.dispatcher_data_prod.data.data_unit) >= 1:
             for unit_id, unit in enumerate(self.dispatcher_data_prod.data.data_unit):
                 if unit.header.get('IMATYPE', '') == 'SIGNIFICANCE' and unit.header.get('XTENSION', '') == 'IMAGE':
                     data_id = unit_id

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -417,4 +417,13 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
                          extra_metadata=extra_metadata)
 
     def get_html_draw(self):
-        return self.dispatcher_data_prod.get_html_draw()  # type: ignore
+
+        if len(self.dispatcher_data_prod.data.data_unit) == 1:
+            data_id = 0
+        else:
+            for id, unit in enumerate(self.dispatcher_data_prod.data.data_unit):
+                if unit.header.get('IMATYPE', '') == 'SIGNIFICANCE' and unit.header.get('XTENSION', '') == 'IMAGE':
+                    data_id = id
+                    break
+
+        return self.dispatcher_data_prod.get_html_draw(data_ID=data_id)  # type: ignore

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -418,8 +418,8 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
 
     def get_html_draw(self):
         # If there is only one extension of the fits file, it is a primary, and therefore it is the only one suitable to be an image.
-        # The other option is specific to INTEGRAL products, where we want to display the significance map among other extensions.
-        # Note that if criteria are not met, it will end up with taking the last extension.
+        # The other option is for INTEGRAL products, where we want to display the significance map among other extensions.
+        # Note that if criteria are not met, it will end up with taking the first extension.
         # In the case a new instrument is added, a further adaptation might be needed.
         data_id = 0
         if len(self.dispatcher_data_prod.data.data_unit) > 1:

--- a/dispatcher_plugin_nb2workflow/products.py
+++ b/dispatcher_plugin_nb2workflow/products.py
@@ -420,7 +420,7 @@ class NB2WImageProduct(NB2WNumpyDataProduct):
         # If there is only one extension of the fits file, it is a primary, and therefore it is the only one suitable to be an image.
         # The other option is specific to INTEGRAL products, where we want to display the significance map among other extensions.
         # Note that if criteria are not met, it will end up with taking the last extension.
-        # It is an improvement on the current situation, but should we add new instruments, we might need to introduce adaptations.
+        # In the case a new instrument is added, a further adaptation might be needed.
         data_id = 0
         if len(self.dispatcher_data_prod.data.data_unit) == 1:
             data_id = 0


### PR DESCRIPTION
The issue

![image](https://github.com/user-attachments/assets/0e1abc8d-15ee-4b66-89f7-a430ea9c03a1)

is caused by an inaccurate reading of the correct data_unit inside the product, with this change, we check the content of the header to make sure we read the correct unit